### PR TITLE
move nock to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "typescript": "^3.7.5"
   },
   "peerDependencies": {
-    "nock": "11.x"
+    "nock": "^11.0.0"
   },
   "dependencies": {
     "stack-trace": "^0.0.10"

--- a/package.json
+++ b/package.json
@@ -52,8 +52,10 @@
     "ts-node": "^5.0.1",
     "typescript": "^3.7.5"
   },
+  "peerDependencies": {
+    "nock": "11.x"
+  },
   "dependencies": {
-    "nock": "^11.7.2",
     "stack-trace": "^0.0.10"
   }
 }


### PR DESCRIPTION
This is needed to avoid second nock installation in case of version mismatch